### PR TITLE
Feature/37 guest can see released

### DIFF
--- a/dist/swagger.json
+++ b/dist/swagger.json
@@ -47,8 +47,8 @@
             "x-nestia-encrypted": false
           }
         },
-        "summary": "@tag admin/animation\n@enum season",
-        "description": "@tag admin/animation\n@enum season.quarter: [1, 2, 3, 4]",
+        "summary": "@tag admin/animation\n@enum seasonQuarter: [1, 2, 3, 4]\n@seriesGroup 시리즈인 경우 대표적인 이름",
+        "description": "@tag admin/animation\n@enum seasonQuarter: [1, 2, 3, 4]\n@seriesGroup 시리즈인 경우 대표적인 이름. ex) [에반게리온 서, 파, Q] -> 에반게리온",
         "x-nestia-namespace": "animation.store",
         "x-nestia-jsDocTags": [
           {
@@ -65,6 +65,15 @@
             "text": [
               {
                 "text": ": [1, 2, 3, 4]",
+                "kind": "text"
+              }
+            ]
+          },
+          {
+            "name": "seriesGroup",
+            "text": [
+              {
+                "text": "시리즈인 경우 대표적인 이름. ex) [에반게리온 서, 파, Q] -> 에반게리온",
                 "kind": "text"
               }
             ]
@@ -162,7 +171,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_plot:_space_string;_space_broadcastType:_space_BroadcastType;_space_episodeNumber:_space_number;_space_imageUrl:_space_string;_space_rating:_space_Rating;_space_primaryKeyword:_space_string;_space_status:_space_Status;_space_..._space_5_space_more_space_...;_space_deletedAt:_space_Date_space__or__space_null;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_"
+                  "$ref": "#/components/schemas/GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_plot:_space_string;_space_broadcastType:_space_BroadcastType;_space_episodeNumber:_space_number;_space_imageUrl:_space_string;_space_rating:_space_Rating;_space_primaryKeyword:_space_string;_space_status:_space_Status;_space_..._space_8_space_more_space_...;_space_deletedAt:_space_Date_space__or__space_null;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_"
                 }
               }
             },
@@ -205,7 +214,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_plot:_space_string;_space_broadcastType:_space_BroadcastType;_space_episodeNumber:_space_number;_space_imageUrl:_space_string;_space_rating:_space_Rating;_space_primaryKeyword:_space_string;_space_status:_space_Status;_space_..._space_5_space_more_space_...;_space_deletedAt:_space_Date_space__or__space_null;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_"
+                  "$ref": "#/components/schemas/GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_plot:_space_string;_space_broadcastType:_space_BroadcastType;_space_episodeNumber:_space_number;_space_imageUrl:_space_string;_space_rating:_space_Rating;_space_primaryKeyword:_space_string;_space_status:_space_Status;_space_..._space_8_space_more_space_...;_space_deletedAt:_space_Date_space__or__space_null;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_"
                 }
               }
             },
@@ -397,6 +406,53 @@
         "x-nestia-method": "DELETE"
       }
     },
+    "/studio": {
+      "post": {
+        "tags": [
+          "admin/studio"
+        ],
+        "parameters": [],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StudioCreateDto"
+              }
+            }
+          },
+          "required": true,
+          "x-nestia-encrypted": false
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_createdAt:_space_Date;_space_updatedAt:_space_Date;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_"
+                }
+              }
+            },
+            "x-nestia-encrypted": false
+          }
+        },
+        "description": "@tag admin/studio",
+        "x-nestia-namespace": "studio.store",
+        "x-nestia-jsDocTags": [
+          {
+            "name": "tag",
+            "text": [
+              {
+                "text": "admin/studio",
+                "kind": "text"
+              }
+            ]
+          }
+        ],
+        "x-nestia-method": "POST"
+      }
+    },
     "/members/signup": {
       "post": {
         "tags": [
@@ -549,7 +605,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/__type.o1"
+                    "$ref": "#/components/schemas/__type"
                   }
                 }
               }
@@ -1268,53 +1324,6 @@
         "x-nestia-method": "DELETE"
       }
     },
-    "/studio": {
-      "post": {
-        "tags": [
-          "admin/studio"
-        ],
-        "parameters": [],
-        "requestBody": {
-          "description": "",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/StudioCreateDto"
-              }
-            }
-          },
-          "required": true,
-          "x-nestia-encrypted": false
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_createdAt:_space_Date;_space_updatedAt:_space_Date;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_"
-                }
-              }
-            },
-            "x-nestia-encrypted": false
-          }
-        },
-        "description": "@tag admin/studio",
-        "x-nestia-namespace": "studio.store",
-        "x-nestia-jsDocTags": [
-          {
-            "name": "tag",
-            "text": [
-              {
-                "text": "admin/studio",
-                "kind": "text"
-              }
-            ]
-          }
-        ],
-        "x-nestia-method": "POST"
-      }
-    },
     "/auth/google/login": {
       "get": {
         "tags": [
@@ -1633,6 +1642,73 @@
           "status": {
             "$ref": "#/components/schemas/Status"
           },
+          "seasonYear": {
+            "description": "@default 2023",
+            "x-typia-jsDocTags": [
+              {
+                "name": "default",
+                "text": [
+                  {
+                    "text": "2023",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number",
+            "default": 2023
+          },
+          "seasonQuarter": {
+            "description": "@default 1\n@enum [1, 2, 3, 4]",
+            "x-typia-jsDocTags": [
+              {
+                "name": "default",
+                "text": [
+                  {
+                    "text": "1",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "enum"
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number",
+            "default": 1
+          },
+          "seriesGroup": {
+            "description": "@default 에반게리온\n@description 시리즈인 경우 대표적인 이름. ex) [에반게리온 서, 파, Q] -> 에반게리온",
+            "x-typia-jsDocTags": [
+              {
+                "name": "default",
+                "text": [
+                  {
+                    "text": "에반게리온",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "description",
+                "text": [
+                  {
+                    "text": "시리즈인 경우 대표적인 이름. ex) [에반게리온 서, 파, Q] -> 에반게리온",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string",
+            "default": "에반게리온",
+            "nullable": true
+          },
           "isReleased": {
             "description": "@default true",
             "x-typia-jsDocTags": [
@@ -1704,28 +1780,8 @@
               "default": "가이낙스"
             }
           },
-          "seasons": {
-            "description": "@default 가이낙스",
-            "x-typia-jsDocTags": [
-              {
-                "name": "default",
-                "text": [
-                  {
-                    "text": "가이낙스",
-                    "kind": "text"
-                  }
-                ]
-              }
-            ],
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/__type"
-            }
-          },
           "genres": {
-            "description": "@default FANTASY\n@enum GenreType",
+            "description": "@default FANTASY",
             "x-typia-jsDocTags": [
               {
                 "name": "default",
@@ -1735,16 +1791,28 @@
                     "kind": "text"
                   }
                 ]
-              },
-              {
-                "name": "enum"
               }
             ],
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/GenreType"
+              "description": "@default FANTASY",
+              "x-typia-jsDocTags": [
+                {
+                  "name": "default",
+                  "text": [
+                    {
+                      "text": "FANTASY",
+                      "kind": "text"
+                    }
+                  ]
+                }
+              ],
+              "x-typia-required": true,
+              "x-typia-optional": false,
+              "type": "string",
+              "default": "FANTASY"
             }
           },
           "voiceActors": {
@@ -1845,10 +1913,12 @@
           "rating",
           "primaryKeyword",
           "status",
+          "seasonYear",
+          "seasonQuarter",
+          "seriesGroup",
           "isReleased",
           "imageUrl",
           "studioNames",
-          "seasons",
           "genres",
           "voiceActors",
           "originalWorkers"
@@ -1882,43 +1952,6 @@
           "UNKNOWN"
         ]
       },
-      "__type": {
-        "type": "object",
-        "properties": {
-          "year": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          },
-          "quarter": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          }
-        },
-        "nullable": false,
-        "required": [
-          "year",
-          "quarter"
-        ],
-        "x-typia-jsDocTags": []
-      },
-      "GenreType": {
-        "type": "string",
-        "enum": [
-          "FANTASY",
-          "SF",
-          "ROMANCE",
-          "ACTION",
-          "ADVANTURE",
-          "ANOTHER_WORLD",
-          "FAMILY",
-          "GAG",
-          "TOUCHING",
-          "CRIME",
-          "DRAMA"
-        ]
-      },
       "AnimationItemResDto": {
         "type": "object",
         "properties": {
@@ -1935,23 +1968,7 @@
               "$ref": "#/components/schemas/GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_createdAt:_space_Date;_space_updatedAt:_space_Date;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_"
             }
           },
-          "seasons": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/GetResult_lt__blt__space_id:_space_number;_space_animationId:_space_number;_space_year:_space_number;_space_quarter:_space_number;_space_createdAt:_space_Date;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_"
-            }
-          },
           "genres": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/GetResult_lt__blt__space_id:_space_number;_space_type:_space_GenreType;_space_createdAt:_space_Date;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_"
-            }
-          },
-          "voiceActors": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "array",
@@ -1959,12 +1976,20 @@
               "$ref": "#/components/schemas/GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_createdAt:_space_Date;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_"
             }
           },
-          "originalWorkers": {
+          "voiceActors": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_createdAt:_space_Date;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_.o1"
+            }
+          },
+          "originalWorkers": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_createdAt:_space_Date;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_.o2"
             }
           },
           "name": {
@@ -2111,6 +2136,73 @@
             ],
             "default": "ONGOING"
           },
+          "seasonYear": {
+            "description": "@default 2023",
+            "x-typia-jsDocTags": [
+              {
+                "name": "default",
+                "text": [
+                  {
+                    "text": "2023",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": false,
+            "x-typia-optional": false,
+            "type": "number",
+            "default": 2023
+          },
+          "seasonQuarter": {
+            "description": "@default 1\n@enum [1, 2, 3, 4]",
+            "x-typia-jsDocTags": [
+              {
+                "name": "default",
+                "text": [
+                  {
+                    "text": "1",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "enum"
+              }
+            ],
+            "x-typia-required": false,
+            "x-typia-optional": false,
+            "type": "number",
+            "default": 1
+          },
+          "seriesGroup": {
+            "description": "@default 에반게리온\n@description 시리즈인 경우 대표적인 이름. ex) [에반게리온 서, 파, Q] -> 에반게리온",
+            "x-typia-jsDocTags": [
+              {
+                "name": "default",
+                "text": [
+                  {
+                    "text": "에반게리온",
+                    "kind": "text"
+                  }
+                ]
+              },
+              {
+                "name": "description",
+                "text": [
+                  {
+                    "text": "시리즈인 경우 대표적인 이름. ex) [에반게리온 서, 파, Q] -> 에반게리온",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": false,
+            "x-typia-optional": false,
+            "type": "string",
+            "default": "에반게리온",
+            "nullable": true
+          },
           "isReleased": {
             "description": "@default true",
             "x-typia-jsDocTags": [
@@ -2152,7 +2244,6 @@
         "required": [
           "id",
           "studios",
-          "seasons",
           "genres",
           "voiceActors",
           "originalWorkers"
@@ -2191,72 +2282,6 @@
           "name",
           "createdAt",
           "updatedAt"
-        ],
-        "x-typia-jsDocTags": []
-      },
-      "GetResult_lt__blt__space_id:_space_number;_space_animationId:_space_number;_space_year:_space_number;_space_quarter:_space_number;_space_createdAt:_space_Date;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          },
-          "createdAt": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string",
-            "format": "date-time"
-          },
-          "animationId": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          },
-          "year": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          },
-          "quarter": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          }
-        },
-        "nullable": false,
-        "required": [
-          "id",
-          "createdAt",
-          "animationId",
-          "year",
-          "quarter"
-        ],
-        "x-typia-jsDocTags": []
-      },
-      "GetResult_lt__blt__space_id:_space_number;_space_type:_space_GenreType;_space_createdAt:_space_Date;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          },
-          "createdAt": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string",
-            "format": "date-time"
-          },
-          "type": {
-            "$ref": "#/components/schemas/GenreType"
-          }
-        },
-        "nullable": false,
-        "required": [
-          "id",
-          "createdAt",
-          "type"
         ],
         "x-typia-jsDocTags": []
       },
@@ -2316,7 +2341,35 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_plot:_space_string;_space_broadcastType:_space_BroadcastType;_space_episodeNumber:_space_number;_space_imageUrl:_space_string;_space_rating:_space_Rating;_space_primaryKeyword:_space_string;_space_status:_space_Status;_space_..._space_5_space_more_space_...;_space_deletedAt:_space_Date_space__or__space_null;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_": {
+      "GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_createdAt:_space_Date;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_.o2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "name": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string"
+          },
+          "createdAt": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "id",
+          "name",
+          "createdAt"
+        ],
+        "x-typia-jsDocTags": []
+      },
+      "GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_plot:_space_string;_space_broadcastType:_space_BroadcastType;_space_episodeNumber:_space_number;_space_imageUrl:_space_string;_space_rating:_space_Rating;_space_primaryKeyword:_space_string;_space_status:_space_Status;_space_..._space_8_space_more_space_...;_space_deletedAt:_space_Date_space__or__space_null;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_": {
         "type": "object",
         "properties": {
           "id": {
@@ -2357,6 +2410,22 @@
           },
           "status": {
             "$ref": "#/components/schemas/Status"
+          },
+          "seasonYear": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "seasonQuarter": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "number"
+          },
+          "seriesGroup": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string",
+            "nullable": true
           },
           "isReleased": {
             "x-typia-required": true,
@@ -2403,6 +2472,9 @@
           "rating",
           "primaryKeyword",
           "status",
+          "seasonYear",
+          "seasonQuarter",
+          "seriesGroup",
           "isReleased",
           "viewCount",
           "reviewCount",
@@ -2546,6 +2618,35 @@
         "required": [
           "id"
         ],
+        "x-typia-jsDocTags": []
+      },
+      "GenreCreateDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "@default GenreType",
+            "x-typia-jsDocTags": [
+              {
+                "name": "default",
+                "text": [
+                  {
+                    "text": "GenreType",
+                    "kind": "text"
+                  }
+                ]
+              }
+            ],
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string",
+            "default": "GenreType"
+          }
+        },
+        "nullable": false,
+        "required": [
+          "name"
+        ],
+        "description": "@default GenreType",
         "x-typia-jsDocTags": []
       },
       "UpdateNameDto": {
@@ -2860,7 +2961,7 @@
         "description": "@minimum 1\n@maximum 20\n@default 20\n@example 20\n@description 한번에 가져올 데이터의 양",
         "x-typia-jsDocTags": []
       },
-      "__type.o1": {
+      "__type": {
         "type": "object",
         "properties": {
           "id": {
@@ -2869,7 +2970,7 @@
             "type": "number"
           },
           "animation": {
-            "$ref": "#/components/schemas/__type.o2"
+            "$ref": "#/components/schemas/__type.o1"
           },
           "createdAt": {
             "x-typia-required": true,
@@ -2886,7 +2987,7 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "__type.o2": {
+      "__type.o1": {
         "type": "object",
         "properties": {
           "id": {
@@ -3807,11 +3908,11 @@
       "AttractionElement": {
         "type": "string",
         "enum": [
-          "ACTION",
           "PAINTING",
           "STORY",
           "BGM",
           "CHARACTER",
+          "ACTION",
           "IMMERSIBILITY"
         ]
       },

--- a/dist/swagger.json
+++ b/dist/swagger.json
@@ -171,7 +171,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_plot:_space_string;_space_broadcastType:_space_BroadcastType;_space_episodeNumber:_space_number;_space_imageUrl:_space_string;_space_rating:_space_Rating;_space_primaryKeyword:_space_string;_space_status:_space_Status;_space_..._space_8_space_more_space_...;_space_deletedAt:_space_Date_space__or__space_null;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_"
+                  "$ref": "#/components/schemas/AnimationItemResDto"
                 }
               }
             },
@@ -209,15 +209,8 @@
           }
         ],
         "responses": {
-          "200": {
+          "204": {
             "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_plot:_space_string;_space_broadcastType:_space_BroadcastType;_space_episodeNumber:_space_number;_space_imageUrl:_space_string;_space_rating:_space_Rating;_space_primaryKeyword:_space_string;_space_status:_space_Status;_space_..._space_8_space_more_space_...;_space_deletedAt:_space_Date_space__or__space_null;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_"
-                }
-              }
-            },
             "x-nestia-encrypted": false
           }
         },
@@ -2369,121 +2362,6 @@
         ],
         "x-typia-jsDocTags": []
       },
-      "GetResult_lt__blt__space_id:_space_number;_space_name:_space_string;_space_plot:_space_string;_space_broadcastType:_space_BroadcastType;_space_episodeNumber:_space_number;_space_imageUrl:_space_string;_space_rating:_space_Rating;_space_primaryKeyword:_space_string;_space_status:_space_Status;_space_..._space_8_space_more_space_...;_space_deletedAt:_space_Date_space__or__space_null;_space__bgt__comma__space_unknown_gt__space__and__space__blt__bgt_": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          },
-          "name": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string"
-          },
-          "plot": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string"
-          },
-          "broadcastType": {
-            "$ref": "#/components/schemas/BroadcastType"
-          },
-          "episodeNumber": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          },
-          "imageUrl": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string"
-          },
-          "rating": {
-            "$ref": "#/components/schemas/Rating"
-          },
-          "primaryKeyword": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string"
-          },
-          "status": {
-            "$ref": "#/components/schemas/Status"
-          },
-          "seasonYear": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          },
-          "seasonQuarter": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          },
-          "seriesGroup": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string",
-            "nullable": true
-          },
-          "isReleased": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "boolean"
-          },
-          "viewCount": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          },
-          "reviewCount": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "number"
-          },
-          "createdAt": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string",
-            "format": "date-time"
-          },
-          "updatedAt": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string",
-            "format": "date-time"
-          },
-          "deletedAt": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string",
-            "format": "date-time"
-          }
-        },
-        "nullable": false,
-        "required": [
-          "id",
-          "name",
-          "plot",
-          "broadcastType",
-          "episodeNumber",
-          "imageUrl",
-          "rating",
-          "primaryKeyword",
-          "status",
-          "seasonYear",
-          "seasonQuarter",
-          "seriesGroup",
-          "isReleased",
-          "viewCount",
-          "reviewCount",
-          "createdAt",
-          "updatedAt",
-          "deletedAt"
-        ],
-        "x-typia-jsDocTags": []
-      },
       "AnimationListDto": {
         "type": "object",
         "properties": {
@@ -3046,19 +2924,7 @@
             "x-typia-optional": false,
             "type": "string"
           },
-          "imageUrl": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string",
-            "nullable": true
-          },
           "createdAt": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string",
-            "format": "date-time"
-          },
-          "updatedAt": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "string",
@@ -3078,10 +2944,22 @@
           "role": {
             "$ref": "#/components/schemas/Role"
           },
+          "imageUrl": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string",
+            "nullable": true
+          },
           "point": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "number"
+          },
+          "updatedAt": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string",
+            "format": "date-time"
           }
         },
         "nullable": false,
@@ -3089,13 +2967,13 @@
           "reviews",
           "reviewLikes",
           "name",
-          "imageUrl",
           "createdAt",
-          "updatedAt",
           "memberId",
           "info",
           "role",
-          "point"
+          "imageUrl",
+          "point",
+          "updatedAt"
         ],
         "description": "\n@nullable\n@session\n",
         "x-typia-jsDocTags": []
@@ -4059,19 +3937,7 @@
             "x-typia-optional": false,
             "type": "string"
           },
-          "imageUrl": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string",
-            "nullable": true
-          },
           "createdAt": {
-            "x-typia-required": true,
-            "x-typia-optional": false,
-            "type": "string",
-            "format": "date-time"
-          },
-          "updatedAt": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "string",
@@ -4091,22 +3957,34 @@
           "role": {
             "$ref": "#/components/schemas/Role"
           },
+          "imageUrl": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string",
+            "nullable": true
+          },
           "point": {
             "x-typia-required": true,
             "x-typia-optional": false,
             "type": "number"
+          },
+          "updatedAt": {
+            "x-typia-required": true,
+            "x-typia-optional": false,
+            "type": "string",
+            "format": "date-time"
           }
         },
         "nullable": false,
         "required": [
           "name",
-          "imageUrl",
           "createdAt",
-          "updatedAt",
           "memberId",
           "info",
           "role",
-          "point"
+          "imageUrl",
+          "point",
+          "updatedAt"
         ],
         "x-typia-jsDocTags": []
       }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,20 +65,25 @@ model Animation {
   rating         Rating
   primaryKeyword String
   status         Status
-  isReleased     Boolean       @default(false)
-  viewCount      Int           @default(0)
-  reviewCount    Int           @default(0)
-  createdAt      DateTime      @default(now())
-  updatedAt      DateTime      @default(now()) @updatedAt
-  deletedAt      DateTime?
+
+  seasonYear    Int     @default(dbgenerated("DATE_PART('year', now())"))
+  seasonQuarter Int     @default(dbgenerated("CEIL(DATE_PART('month', now()) / 4)"))
+  seriesGroup   String? /// 특정시리즈 이름. 가장 대포적인 이름. [사이버포뮬러11, zero, 신....] -> 사이버포뮬러 | [에반게리온 Q, 파, 오리지널...] -> 에반게리온
+
+  isReleased  Boolean   @default(false)
+  viewCount   Int       @default(0)
+  reviewCount Int       @default(0)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @default(now()) @updatedAt
+  deletedAt   DateTime?
 
   studios         AnimationStudio[]
   genres          AnimationGenre[]
   voiceActors     AnimationVoiceActor[]
   originalWorkers AnimationOriginalWorker[]
   keywords        Keyword[]
-  seasons         Season[]
-  bookmarks       Bookmark[]
+
+  bookmarks Bookmark[]
 }
 
 model AnimationGenre {
@@ -121,9 +126,9 @@ model AnimationOriginalWorker {
 }
 
 model Genre {
-  id        Int       @id @default(autoincrement())
-  type      GenreType @unique
-  createdAt DateTime  @default(now())
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  createdAt DateTime @default(now())
 
   animations AnimationGenre[]
 }
@@ -157,15 +162,6 @@ model Keyword {
   keyword     String
   createdAt   DateTime  @default(now())
   animation   Animation @relation(fields: [animationId], references: [id])
-}
-
-model Season {
-  id          Int       @id @default(autoincrement())
-  animationId Int
-  year        Int       @default(0)
-  quarter     Int       @default(0)
-  createdAt   DateTime  @default(now())
-  animation   Animation @relation(fields: [animationId], references: [id], onDelete: Cascade)
 }
 
 model Review {
@@ -296,20 +292,6 @@ enum Status {
   ONGOING
   UPCOMING
   UNKNOWN
-}
-
-enum GenreType {
-  FANTASY
-  SF
-  ROMANCE
-  ACTION
-  ADVANTURE
-  ANOTHER_WORLD
-  FAMILY
-  GAG
-  TOUCHING
-  CRIME
-  DRAMA
 }
 
 enum ReviewType {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { PrismaModule } from './global/database/prisma/prisma.module';
 import { HttpExceptionFilter } from './global/common/filter/http-exception.filter';
 import { PrismaExceptionFilter } from './global/common/filter/prisma-exception.filter';
 import { BookmarkModule } from './domain/bookmark/bookmark.module';
+import { GenreModule } from './domain/genre/genre.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { BookmarkModule } from './domain/bookmark/bookmark.module';
     MemberModule,
     AnimationModule,
     StudioModule,
+    GenreModule,
     ReviewsModule,
     BookmarkModule,
   ],

--- a/src/domain/animation/admin.animation.controller.ts
+++ b/src/domain/animation/admin.animation.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, UseGuards } from '@nestjs/common';
+import { Controller, HttpCode, UseGuards } from '@nestjs/common';
 import { AnimationService } from './animation.service';
 import { TypedBody, TypedParam, TypedRoute } from '@nestia/core';
 import { Animation, Role } from '@prisma/client';
@@ -6,6 +6,7 @@ import { AnimationReqDto, AnimationUpdateDto } from './dto/animation.req.dto';
 import { AnimationItemResDto } from './dto/animation.res.dto';
 import { Roles } from '../../global/common/decoratror/roles.decorator';
 import { RolesGuard } from '../../global/auth/guard/roles.guard';
+import { ApiNoContentResponse } from '@nestjs/swagger';
 
 @Controller('/animation')
 export class AdminAnimationController {
@@ -34,7 +35,7 @@ export class AdminAnimationController {
   async update(
     @TypedParam('id') id: number,
     @TypedBody() body: AnimationReqDto,
-  ): Promise<Animation> {
+  ): Promise<AnimationItemResDto> {
     return this.service.updateById(id, body);
   }
 
@@ -42,9 +43,10 @@ export class AdminAnimationController {
    * @tag admin/animation
    */
   @TypedRoute.Delete('/:id')
+  @HttpCode(204)
   // @UseGuards(RolesGuard)
   // @Roles(Role.ADMIN)
-  async destroy(@TypedParam('id') id: number): Promise<Animation> {
+  async destroy(@TypedParam('id') id: number): Promise<void> {
     return this.service.destroyById(id);
   }
 }

--- a/src/domain/animation/admin.animation.controller.ts
+++ b/src/domain/animation/admin.animation.controller.ts
@@ -13,7 +13,8 @@ export class AdminAnimationController {
 
   /**
    * @tag admin/animation
-   * @enum season.quarter: [1, 2, 3, 4]
+   * @enum seasonQuarter: [1, 2, 3, 4]
+   * @seriesGroup 시리즈인 경우 대표적인 이름. ex) [에반게리온 서, 파, Q] -> 에반게리온
    */
   @TypedRoute.Post('/')
   // @UseGuards(RolesGuard)

--- a/src/domain/animation/animation.controller.ts
+++ b/src/domain/animation/animation.controller.ts
@@ -19,8 +19,6 @@ export class AnimationController {
    */
   @TypedRoute.Get('/')
   @ApiOperation({ summary: 'animation list' })
-  @UseGuards(RolesGuard)
-  @Roles(Role.MEMBER, Role.ADMIN)
   async getList(
     @User() user: MemberProfile,
     @TypedQuery() query: AnimationListDto,
@@ -32,8 +30,6 @@ export class AnimationController {
    * @tag animation
    */
   @TypedRoute.Get('/:id')
-  @UseGuards(RolesGuard)
-  @Roles(Role.MEMBER, Role.ADMIN)
   async show(
     @User() user: MemberProfile,
     @TypedParam('id') id: number,

--- a/src/domain/animation/animation.repository.ts
+++ b/src/domain/animation/animation.repository.ts
@@ -1,4 +1,8 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { PrismaService } from '../../global/database/prisma/prisma.service';
 import { AnimationListDto } from './dto/animation.req.dto';
 import { AnimationReqDto } from './dto/animation.req.dto';
@@ -127,15 +131,13 @@ export class AnimationRepository {
   }
 
   async getAnimationById(role: Role, id: number) {
-    const animation = await this.prisma.animation.findFirst({
-      where: { id },
+    return this.prisma.animation.findFirstOrThrow({
+      where: {
+        id,
+        isReleased: role === Role.ADMIN ? {} : true,
+      },
       include: this.makeCommonIncludeQuery(),
     });
-
-    if (role !== Role.ADMIN && !animation?.isReleased)
-      throw new UnauthorizedException('NotReleased');
-
-    return animation;
   }
 
   async storeAnimation(body: AnimationReqDto) {

--- a/src/domain/animation/animation.repository.ts
+++ b/src/domain/animation/animation.repository.ts
@@ -1,8 +1,4 @@
-import {
-  Injectable,
-  NotFoundException,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../global/database/prisma/prisma.service';
 import { AnimationListDto } from './dto/animation.req.dto';
 import { AnimationReqDto } from './dto/animation.req.dto';
@@ -36,7 +32,6 @@ export class AnimationRepository {
         },
       },
       // TODO: keywords
-      seasons: true,
     };
   }
 
@@ -46,7 +41,6 @@ export class AnimationRepository {
       genres,
       voiceActors,
       originalWorkers,
-      seasons,
       ...animationBody
     } = body;
 
@@ -69,8 +63,8 @@ export class AnimationRepository {
         create: genres.map((g) => ({
           genre: {
             connectOrCreate: {
-              where: { type: g },
-              create: { type: g },
+              where: { name: g },
+              create: { name: g },
             },
           },
         })),
@@ -97,13 +91,6 @@ export class AnimationRepository {
           },
         })),
       },
-      seasons: {
-        deleteMany: id ? { animationId: id } : undefined,
-        create: seasons.map((s) => ({
-          year: s.year,
-          quarter: s.quarter,
-        })),
-      },
       // TODO: keywords
     };
   }
@@ -112,6 +99,7 @@ export class AnimationRepository {
     const search = {
       OR: [
         { name: { contains: params.search ?? '' } },
+        { seriesGroup: { contains: params.search ?? '' } },
         { plot: { contains: params.search ?? '' } },
         { primaryKeyword: { contains: params.search ?? '' } },
       ],

--- a/src/domain/animation/animation.repository.ts
+++ b/src/domain/animation/animation.repository.ts
@@ -110,6 +110,7 @@ export class AnimationRepository {
     return this.prisma.animation.findMany({
       skip: params.lastId ? 1 : 0,
       take: params.pageSize ?? 20,
+      cursor: params.lastId ? { id: params.lastId } : undefined,
       orderBy: {
         [params.sortBy ?? 'createdAt']: params.sortOrder ?? Sort.DESC,
       },
@@ -136,16 +137,14 @@ export class AnimationRepository {
   }
 
   async updateAnimation(id: number, body: AnimationReqDto) {
-    return this.prisma.$transaction(async (tx) => {
-      return tx.animation.update({
-        where: { id },
-        data: this.makeCommonBodyQuery(body, id),
-        include: this.makeCommonIncludeQuery(),
-      });
+    return this.prisma.animation.update({
+      where: { id },
+      data: this.makeCommonBodyQuery(body, id),
+      include: this.makeCommonIncludeQuery(),
     });
   }
 
   async destroyById(id: number) {
-    return this.prisma.animation.delete({ where: { id } });
+    await this.prisma.animation.delete({ where: { id } });
   }
 }

--- a/src/domain/animation/animation.service.ts
+++ b/src/domain/animation/animation.service.ts
@@ -22,32 +22,30 @@ export class AnimationService {
     query: AnimationListDto,
   ): Promise<AnimationItemResDto[]> {
     const items = await this.repository.getAnimations(user.role, query);
-    return this.flattenStudios(items);
+    return this.flattenRelations(items);
   }
 
   async getOneById(user: MemberProfile, id: number) {
     const item = await this.repository.getAnimationById(user.role, id);
 
-    if (!item) throw new NotFoundException();
-
-    return this.flattenStudios([item])[0];
+    return this.flattenRelations([item])[0];
   }
 
   async store(body: AnimationReqDto) {
     const item = await this.repository.storeAnimation(body);
-    return this.flattenStudios([item])[0];
+    return this.flattenRelations([item])[0];
   }
 
   async updateById(id: number, body: AnimationReqDto): Promise<Animation> {
     const item = await this.repository.updateAnimation(id, body);
-    return this.flattenStudios([item])[0];
+    return this.flattenRelations([item])[0];
   }
 
   async destroyById(id: number): Promise<Animation> {
     return await this.repository.destroyById(Number(id));
   }
 
-  private flattenStudios(
+  private flattenRelations(
     items: (Animation & {
       studios: { studio: Studio }[];
       seasons: Season[];

--- a/src/domain/animation/animation.service.ts
+++ b/src/domain/animation/animation.service.ts
@@ -35,12 +35,15 @@ export class AnimationService {
     return this.flattenRelations([item])[0];
   }
 
-  async updateById(id: number, body: AnimationReqDto): Promise<Animation> {
+  async updateById(
+    id: number,
+    body: AnimationReqDto,
+  ): Promise<AnimationItemResDto> {
     const item = await this.repository.updateAnimation(id, body);
     return this.flattenRelations([item])[0];
   }
 
-  async destroyById(id: number): Promise<Animation> {
+  async destroyById(id: number): Promise<void> {
     return await this.repository.destroyById(Number(id));
   }
 

--- a/src/domain/animation/animation.service.ts
+++ b/src/domain/animation/animation.service.ts
@@ -1,16 +1,15 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { AnimationRepository } from './animation.repository';
 import {
   Animation,
   Genre,
   MemberProfile,
   OriginalWorker,
-  Season,
   Studio,
   VoiceActor,
 } from '@prisma/client';
 import { AnimationListDto } from './dto/animation.req.dto';
-import { AnimationReqDto, AnimationUpdateDto } from './dto/animation.req.dto';
+import { AnimationReqDto } from './dto/animation.req.dto';
 import { AnimationItemResDto } from './dto/animation.res.dto';
 
 @Injectable()
@@ -48,7 +47,6 @@ export class AnimationService {
   private flattenRelations(
     items: (Animation & {
       studios: { studio: Studio }[];
-      seasons: Season[];
       genres: { genre: Genre }[];
       voiceActors: { voiceActor: VoiceActor }[];
       originalWorkers: { originalWorker: OriginalWorker }[];

--- a/src/domain/animation/dto/animation.req.dto.ts
+++ b/src/domain/animation/dto/animation.req.dto.ts
@@ -1,4 +1,4 @@
-import { BroadcastType, GenreType, Rating, Status } from '@prisma/client';
+import { BroadcastType, Rating, Status } from '@prisma/client';
 
 export interface AnimationListDto {
   /**
@@ -41,15 +41,9 @@ export interface AnimationRelationDto {
   studioNames: string[];
 
   /**
-   * @default 가이낙스
-   * */
-  seasons: { year: number; quarter: number }[];
-
-  /**
    * @default FANTASY
-   * @enum GenreType
    * */
-  genres: GenreType[];
+  genres: string[];
 
   /**
    * @default 타네다 리사
@@ -100,6 +94,23 @@ export interface AnimationBaseDto {
    * @default ONGOING
    * */
   status: Status;
+
+  /**
+   * @default 2023
+   * */
+  seasonYear: number;
+
+  /**
+   * @default 1
+   * @enum [1, 2, 3, 4]
+   * */
+  seasonQuarter: number;
+
+  /**
+   * @default 에반게리온
+   * @description 시리즈인 경우 대표적인 이름. ex) [에반게리온 서, 파, Q] -> 에반게리온
+   * */
+  seriesGroup: string | null;
 
   /**
    * @default true

--- a/src/domain/animation/dto/animation.res.dto.ts
+++ b/src/domain/animation/dto/animation.res.dto.ts
@@ -1,16 +1,9 @@
 import { AnimationBaseDto } from './animation.req.dto';
-import {
-  Genre,
-  OriginalWorker,
-  Season,
-  Studio,
-  VoiceActor,
-} from '@prisma/client';
+import { Genre, OriginalWorker, Studio, VoiceActor } from '@prisma/client';
 
 export interface AnimationItemResDto extends Partial<AnimationBaseDto> {
   id: number;
   studios: Studio[];
-  seasons: Season[];
   genres: Genre[];
   voiceActors: VoiceActor[];
   originalWorkers: OriginalWorker[];

--- a/src/domain/animation/dto/animation.res.dto.ts
+++ b/src/domain/animation/dto/animation.res.dto.ts
@@ -9,13 +9,3 @@ export interface AnimationItemResDto extends Partial<AnimationBaseDto> {
   originalWorkers: OriginalWorker[];
   // TODO: add keywords
 }
-
-export interface AnimationListResDto {
-  items: AnimationItemResDto[];
-  cursor: string;
-  page: number;
-  size: number;
-  nextPage: number;
-  lastPage: number;
-  total: number;
-}

--- a/src/domain/genre/admin.genre.controller.ts
+++ b/src/domain/genre/admin.genre.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, UseGuards } from '@nestjs/common';
+import { GenreService } from './genre.service';
+import { TypedBody, TypedRoute } from '@nestia/core';
+import { GenreCreateDto } from './dto/genre.create.dto';
+import { Genre, Role } from '@prisma/client';
+import { RolesGuard } from '../../global/auth/guard/roles.guard';
+import { Roles } from '../../global/common/decoratror/roles.decorator';
+
+@Controller('studio')
+export class AdminGenreController {
+  constructor(private readonly service: GenreService) {}
+
+  /**
+   * @tag admin/studio
+   */
+  @TypedRoute.Post('/')
+  @UseGuards(RolesGuard)
+  @Roles(Role.ADMIN)
+  async store(@TypedBody() body: GenreCreateDto): Promise<Genre> {
+    return this.service.store(body);
+  }
+}

--- a/src/domain/genre/dto/genre.create.dto.ts
+++ b/src/domain/genre/dto/genre.create.dto.ts
@@ -1,8 +1,6 @@
-import { GenreType } from '@prisma/client';
-
 export interface GenreCreateDto {
   /**
    * @default GenreType
    * */
-  type: GenreType;
+  name: string;
 }

--- a/src/domain/genre/dto/genre.create.dto.ts
+++ b/src/domain/genre/dto/genre.create.dto.ts
@@ -1,0 +1,8 @@
+import { GenreType } from '@prisma/client';
+
+export interface GenreCreateDto {
+  /**
+   * @default GenreType
+   * */
+  type: GenreType;
+}

--- a/src/domain/genre/genre.controller.ts
+++ b/src/domain/genre/genre.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { GenreService } from './genre.service';
+
+@Controller('studios')
+export class GenreController {
+  constructor(private readonly service: GenreService) {}
+}

--- a/src/domain/genre/genre.module.ts
+++ b/src/domain/genre/genre.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { GenreController } from './genre.controller';
+import { GenreService } from './genre.service';
+import { GenreRepository } from './genre.repository';
+import { AdminGenreController } from './admin.genre.controller';
+
+@Module({
+  controllers: [GenreController, AdminGenreController],
+  providers: [GenreService, GenreRepository],
+})
+export class GenreModule {}

--- a/src/domain/genre/genre.repository.ts
+++ b/src/domain/genre/genre.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../global/database/prisma/prisma.service';
 import { GenreCreateDto } from './dto/genre.create.dto';
-import { Genre, GenreType } from '@prisma/client';
+import { Genre } from '@prisma/client';
 
 @Injectable()
 export class GenreRepository {
@@ -13,5 +13,5 @@ export class GenreRepository {
     });
   }
 
-  async firstOrCreate(type: GenreType, prisma: PrismaService = this.prisma) {}
+  async firstOrCreate(name: string, prisma: PrismaService = this.prisma) {}
 }

--- a/src/domain/genre/genre.repository.ts
+++ b/src/domain/genre/genre.repository.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../global/database/prisma/prisma.service';
+import { GenreCreateDto } from './dto/genre.create.dto';
+import { Genre, GenreType } from '@prisma/client';
+
+@Injectable()
+export class GenreRepository {
+  constructor(private prisma: PrismaService) {}
+
+  async store(body: GenreCreateDto, prisma: PrismaService = this.prisma) {
+    return prisma.genre.create({
+      data: body,
+    });
+  }
+
+  async firstOrCreate(type: GenreType, prisma: PrismaService = this.prisma) {}
+}

--- a/src/domain/genre/genre.service.ts
+++ b/src/domain/genre/genre.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { GenreCreateDto } from './dto/genre.create.dto';
+import { GenreRepository } from './genre.repository';
+
+@Injectable()
+export class GenreService {
+  constructor(private readonly repository: GenreRepository) {}
+  async store(body: GenreCreateDto) {
+    return this.repository.store(body);
+  }
+}

--- a/src/global/common/decoratror/user.decorator.ts
+++ b/src/global/common/decoratror/user.decorator.ts
@@ -1,6 +1,7 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { Role } from '@prisma/client';
 
 export const User = createParamDecorator((data: any, ctx: ExecutionContext) => {
   const request = ctx.switchToHttp().getRequest();
-  return request.user;
+  return request.user ?? { role: Role.GUEST };
 });

--- a/tests/unit/animation/animation.service.spec.ts
+++ b/tests/unit/animation/animation.service.spec.ts
@@ -1,10 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AnimationService } from '../../../src/domain/animation/animation.service';
 import { AnimationRepository } from '../../../src/domain/animation/animation.repository';
-import { PrismaService } from '../../../src/global/database/prisma/prisma.service';
-import { Animation, BroadcastType, Rating, Status } from '@prisma/client';
+import { BroadcastType, GenreType, Rating, Status } from '@prisma/client';
+import { Role } from '.prisma/client';
+import { PrismaModule } from '../../../src/global/database/prisma/prisma.module';
 
-const MOCK_RESULT: Animation = {
+const MOCK_RESULT = {
   id: 1,
   name: '바키',
   plot: '',
@@ -13,13 +14,71 @@ const MOCK_RESULT: Animation = {
   rating: Rating.ADULT,
   primaryKeyword: '',
   status: Status.FINISHED,
-  isReleased: false,
   viewCount: 0,
   reviewCount: 0,
+  isReleased: false,
   imageUrl: 'src/baki.jpg',
   createdAt: new Date(),
   updatedAt: new Date(),
-  deletedAt: null,
+  deletedAt: new Date(),
+  studios: [
+    {
+      studio: {
+        id: 1,
+        name: '지브리스튱디오',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    },
+  ],
+  seasons: [
+    {
+      id: 1,
+      createdAt: new Date(),
+      animationId: 1,
+      year: 2023,
+      quarter: 1,
+    },
+  ],
+  genres: [
+    {
+      genre: {
+        id: 1,
+        createdAt: new Date(),
+        type: GenreType.FANTASY,
+      },
+    },
+  ],
+  voiceActors: [
+    {
+      voiceActor: {
+        id: 1,
+        name: '누구누구',
+        createdAt: new Date(),
+      },
+    },
+  ],
+  originalWorkers: [
+    {
+      originalWorker: {
+        id: 1,
+        name: '데즈카 오사무',
+        createdAt: new Date(),
+      },
+    },
+  ],
+};
+
+const MockUser = {
+  id: 1,
+  memberId: 1,
+  name: 'asd',
+  info: null,
+  role: Role.ADMIN,
+  imageUrl: null,
+  point: 1,
+  createdAt: new Date(),
+  updatedAt: new Date(),
 };
 
 describe('AnimationService', () => {
@@ -28,7 +87,8 @@ describe('AnimationService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [PrismaService, AnimationService, AnimationRepository],
+      imports: [PrismaModule],
+      providers: [AnimationService, AnimationRepository],
     }).compile();
 
     repository = module.get<AnimationRepository>(AnimationRepository);
@@ -43,7 +103,7 @@ describe('AnimationService', () => {
     it('should return all animations', async () => {
       jest.spyOn(repository, 'getAnimations').mockResolvedValue([MOCK_RESULT]);
 
-      const result = await (async () => await service.getList({}))();
+      const result = await (async () => await service.getList(MockUser, {}))();
 
       expect(result[0].name).toContain('바키');
     });
@@ -53,7 +113,8 @@ describe('AnimationService', () => {
     it('should return an animation', async () => {
       jest.spyOn(repository, 'getAnimationById').mockResolvedValue(MOCK_RESULT);
 
-      const result = await (async () => await service.getOneById(1))();
+      const result = await (async () =>
+        await service.getOneById(MockUser, 1))();
 
       expect(result.name).toContain('바키');
     });

--- a/tests/unit/review/short-review.service.spec.ts
+++ b/tests/unit/review/short-review.service.spec.ts
@@ -93,8 +93,8 @@ describe('ShortReviewService', () => {
   });
 
   describe('createShortReview', () => {
-    const memberId: number = 123;
-    const reviewId: number = 456;
+    const memberId = 123;
+    const reviewId = 456;
     const dto: CreateShortReviewDto = {
       rating: 5,
       comment: 'This is test',
@@ -125,9 +125,7 @@ describe('ShortReviewService', () => {
       await expect(
         async () => await service.createShortReview(memberId, reviewId, dto),
       ).rejects.toThrowError(
-        new BadRequestException(
-          `해당 애니메이션에 이미 작성한 한줄 리뷰가 존재합니다.`,
-        ),
+        new BadRequestException(`Already exist short review this animation.`),
       );
     });
   });
@@ -135,7 +133,7 @@ describe('ShortReviewService', () => {
   describe('updateShortReview', () => {
     it('한줄 리뷰 수정', async () => {
       // given
-      const reviewId: number = 1;
+      const reviewId = 1;
       const dto: UpdateShortReviewDto = {
         rating: 5,
         comment: 'This is test',
@@ -157,8 +155,8 @@ describe('ShortReviewService', () => {
   describe('deleteShortReview', () => {
     it('한줄 리뷰 삭제', async () => {
       // given
-      const reviewId: number = 456;
-      const msg: string = `해당 한줄 리뷰를 성공적으로 삭제하였습니다. id = ${reviewId}`;
+      const reviewId = 456;
+      const msg = `해당 한줄 리뷰를 성공적으로 삭제하였습니다. id = ${reviewId}`;
 
       jest
         .spyOn(repository, 'softDeleteShortReview')


### PR DESCRIPTION
## 📝 개요

비로그인 유저 애니메이션 조회 가능
장르 유연성 확보
시즌 컬럼화
시리즈그룹컬럼 추가


## 🚀 변경사항

- @User 에 guest role 추가
- 애니메이션 list / show  에 guard 제거
- admin role 구분 released 필터링
---

- 장르 타입 enum을 폐기하고 name string으로 추가가 쉽게 변경
---

- 시즌 테이블 삭제
- 애니메이션 필드로 seasonYear, seasonQuarter 추가
---

- seriesGroup 추가
- 추후 시리즈 묶는 용도
- list검색시 seariseGroup도 검색

## 🔗 관련 이슈

- 이 feat는 다른 기능 구현중 긴급처리 commit 입니다.
- 스키마 변경이 꽤 들어갔습니다.
  - npm run migrate:dev 필요
  - 현재 db 상태에 따라 데이터 재삽입 필요할 수 있습니다.

## ➕ 기타

